### PR TITLE
Fixes bug introduced in c529f18784e7e1e887cb3f6922d2ab2591dd5174

### DIFF
--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -272,7 +272,7 @@ unknown_local_recipient_reject_code = 550
 #mynetworks = 168.100.189.0/28, 127.0.0.0/8
 #mynetworks = $config_directory/mynetworks
 #mynetworks = hash:/etc/postfix/network_table
-mynetworks = [{% for network in postfix_mynetworks %}{{ network }}{% if not loop.last %}, {% endif %}{% endfor %}]
+mynetworks = {% for network in postfix_mynetworks %}{{ network }}{% if not loop.last %}, {% endif %}{% endfor %}
 
 # The relay_domains parameter restricts what destinations this system will
 # relay mail to.  See the smtpd_recipient_restrictions description in


### PR DESCRIPTION
---
name: Fixes bug introduced in c529f18784e7e1e887cb3f6922d2ab2591dd5174
about: mynetworks should not include brackets

---

**Describe the change**

Commit c529f18784e7e1e887cb3f6922d2ab2591dd5174 added the option to add IPs from a list. While this feature was added the brackets where included. This breaks postfix if multiple IPs are used. Fix is to just remove the brackets from the `main.cf.j2` template which this PR does.


Below is the error that will show if you use multiple IPs with the current template.
```
Oct  8 15:17:25 gw postfix/smtpd[2718]: warning: mynetworks: missing ']' character after "[127.0.0.1/8"
Oct  8 15:17:25 gw postfix/smtpd[2718]: NOQUEUE: reject: RCPT from unknown[[...SNIP...]]: 451 4.3.0 <admin@domain.tld>: Temporary lookup failure; from=<test@otherdomain.tld> to=<admin@domain.tld> proto=SMTP

# cat main.cf | grep 127
#mynetworks = 168.100.189.0/28, 127.0.0.0/8
mynetworks = [127.0.0.1/8, ip.of.mail.host]
#debug_peer_list = 127.0.0.1
```

**Testing**
Ubuntu 20.04
